### PR TITLE
Redirect to home_url if no return url set/found

### DIFF
--- a/includes/confirmations.php
+++ b/includes/confirmations.php
@@ -68,7 +68,7 @@ function dk_speakout_confirm_email() {
 		<html>
 		<head>
 			<meta http-equiv="Content-Type" content="text/html; charset=' . get_bloginfo( "charset" ) . '" />
-			<meta http-equiv="refresh" content="10;' . $the_petition->return_url . '"> 
+			<meta http-equiv="refresh" content="10;' . ($the_petition->return_url ?: home_url()) . '"> 
 			<title>' . get_bloginfo( "name" ) . '</title>
 			<style type="text/css">
 				body {


### PR DESCRIPTION
When the user clicks on the email link a second time, the page keeps refreshing without redirecting. This makes the file redirect to the site's homepage if no url is set.
